### PR TITLE
Explicitly replace "import tensorflow" with "tensorflow.compat.v1"

### DIFF
--- a/multidim_image_augmentation/python/kernel_tests/apply_deformation_op_test.py
+++ b/multidim_image_augmentation/python/kernel_tests/apply_deformation_op_test.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import numpy as np
 from six.moves import range
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from multidim_image_augmentation import augmentation_ops
 

--- a/multidim_image_augmentation/python/kernel_tests/apply_tabulated_functions_op_test.py
+++ b/multidim_image_augmentation/python/kernel_tests/apply_tabulated_functions_op_test.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from multidim_image_augmentation import augmentation_ops
 

--- a/multidim_image_augmentation/python/kernel_tests/cubic_interpolation1d_op_test.py
+++ b/multidim_image_augmentation/python/kernel_tests/cubic_interpolation1d_op_test.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import numpy as np
 from six.moves import range
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from multidim_image_augmentation import augmentation_ops
 

--- a/multidim_image_augmentation/python/kernel_tests/cubic_interpolation2d_op_test.py
+++ b/multidim_image_augmentation/python/kernel_tests/cubic_interpolation2d_op_test.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import numpy as np
 from six.moves import range
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from multidim_image_augmentation import augmentation_ops
 

--- a/multidim_image_augmentation/python/kernel_tests/cubic_interpolation3d_op_test.py
+++ b/multidim_image_augmentation/python/kernel_tests/cubic_interpolation3d_op_test.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import numpy as np
 from six.moves import range
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from multidim_image_augmentation import augmentation_ops
 

--- a/multidim_image_augmentation/python/kernel_tests/random_lut_controlpoints_op_test.py
+++ b/multidim_image_augmentation/python/kernel_tests/random_lut_controlpoints_op_test.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from six.moves import range
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 
 from multidim_image_augmentation import augmentation_ops
 


### PR DESCRIPTION
Explicitly replace "import tensorflow" with "tensorflow.compat.v1"
